### PR TITLE
Add handler in case the existing mmhook is corrupted

### DIFF
--- a/HookGenPatcher.cs
+++ b/HookGenPatcher.cs
@@ -26,6 +26,7 @@ namespace BepInEx.MonoMod.HookGenPatcher
         /**
          * Code largely based on https://github.com/MonoMod/MonoMod/blob/master/MonoMod.RuntimeDetour.HookGen/Program.cs
          */
+
         public static void Initialize()
         {
             var assemblyNames = AssemblyNamesToHookGenPatch.Value.Split(EntrySeparator);
@@ -51,7 +52,7 @@ namespace BepInEx.MonoMod.HookGenPatcher
                     }
                 }
 
-                if(shouldCreateDirectory)
+                if (shouldCreateDirectory)
                 {
                     Directory.CreateDirectory(mmhookFolder);
                 }
@@ -87,7 +88,6 @@ namespace BepInEx.MonoMod.HookGenPatcher
                     ReadingMode = ReadingMode.Deferred
                 })
                 {
-
                     (mm.AssemblyResolver as BaseAssemblyResolver)?.AddSearchDirectory(Paths.BepInExAssemblyDirectory);
 
                     mm.Read();
@@ -117,7 +117,6 @@ namespace BepInEx.MonoMod.HookGenPatcher
 
         public static void Patch(AssemblyDefinition _)
         {
-
         }
     }
 }

--- a/HookGenPatcher.cs
+++ b/HookGenPatcher.cs
@@ -32,7 +32,6 @@ namespace BepInEx.MonoMod.HookGenPatcher
 
             var mmhookFolder = Path.Combine(Paths.PluginPath, "MMHOOK");
 
-
             foreach (var customAssemblyName in assemblyNames)
             {
                 var mmhookFileName = "MMHOOK_" + customAssemblyName;
@@ -60,14 +59,21 @@ namespace BepInEx.MonoMod.HookGenPatcher
 
                 if (File.Exists(pathOut))
                 {
-                    using (var oldMM = AssemblyDefinition.ReadAssembly(pathOut))
+                    try
                     {
-                        bool hash = oldMM.MainModule.GetType("BepHookGen.hash" + size) != null;
-                        if (hash)
+                        using (var oldMM = AssemblyDefinition.ReadAssembly(pathOut))
                         {
-                            Logger.LogInfo("Already ran for this version, reusing that file.");
-                            continue;
+                            bool hash = oldMM.MainModule.GetType("BepHookGen.hash" + size) != null;
+                            if (hash)
+                            {
+                                Logger.LogInfo("Already ran for this version, reusing that file.");
+                                continue;
+                            }
                         }
+                    }
+                    catch (BadImageFormatException)
+                    {
+                        Logger.LogWarning($"Failed to read {Path.GetFileName(pathOut)}, probably corrupted, remaking one.");
                     }
                 }
 


### PR DESCRIPTION
I've seen users getting corrupted MMHOOK files sometimes in their folder, most likely because of abnormal termination of the program, when that happens, ReadAssembly can throw a BadImageFormatException on the next launch. This PR fixes that by catching the exception and letting the program continue, effectively remaking a fresh mmhook